### PR TITLE
Change $HOME in defaults since var is not expanded

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ rsnapshot_config_lockfile: /var/run/rsnapshot.pid
 rsnapshot_config_stop_on_stale_lockfile: 0
 rsnapshot_config_rsync_short_args: False
 rsnapshot_config_rsync_long_args: '--delete --numeric-ids --relative --delete-excluded --rsync-path=rsync-wrapper.sh'
-rsnapshot_config_ssh_args: '-i $HOME/.ssh/{{ rsnapshot_ssh_key }}'
+rsnapshot_config_ssh_args: '-i /root/.ssh/{{ rsnapshot_ssh_key }}'
 rsnapshot_config_du_args: False
 rsnapshot_config_one_fs: False
 rsnapshot_config_include: []


### PR DESCRIPTION
Launching rsnapshot as-is generates the following warning (Tested with
rsnapshot 1.3.1):
"Warning: Identity file $HOME/.ssh/id_rsa not accessible: No such file or
directory."
