### PR TITLE
Ability to run as non-root users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,8 @@ language: python
 python: "2.7"
 
 env:
-  - ANSIBLE_VERSION="1.8,<1.9"
-  - ANSIBLE_VERSION="1.9,<2.0"
-  - ANSIBLE_VERSION="2.0,<2.1"
-  - ANSIBLE_VERSION="2.1,<2.2"
-  - ANSIBLE_VERSION="2.2,<2.3"
+  - ANSIBLE_VERSION="2.4,<2.5"
+  - ANSIBLE_VERSION="2.5,<2.6"
 
 before_install:
   - sudo apt-get update -qq

--- a/README.md
+++ b/README.md
@@ -3,9 +3,13 @@
 Ansible role to install and configure a *rsnapshot* master. It works in
 conjunction with the `rsnapshot-slave` role.
 
-`rsnapshot-master` generates a SSH key for the `root` system user, and
-`rsnapshot-slave` is charged to set up the public key for a dedicated backup
-system user (with limited access rights) on remote hosts.
+`rsnapshot-master` generates a SSH key for the `"{{rsnapshot_master_host_user}}"` system user which is by default `root`, and
+`rsnapshot-slave` is charged to set up the public key for a dedicated backup system user (with limited access rights) on remote hosts.
+
+### Running as non root user
+
+This version allows you to run `rsnapshot` as a non-root user. In this case, you need to enable `rsnapshot_master_host_user_uses_sudo` if you want
+to perform localhost backup also. 
 
 Minimum Ansible Version: 1.4
 
@@ -68,6 +72,10 @@ See the `rsnapshot-slave` role for details about the slave configuration.
 # SSH key for the 'root' user, the public one should be set on remote
 # servers to backup (see the role 'rsnapshot-slave')
 rsnapshot_ssh_key: id_rsa
+rsnapshot_master_host_user:  root
+
+# This is needed if you plan to backup localhost files as non root user
+rsnapshot_master_host_user_uses_sudo: False
 
 # rsnapshot options
 rsnapshot_config_file: /etc/rsnapshot.conf

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the `rsnapshot-slave` role for details about the slave configuration.
 ```yaml
 # SSH key for the 'root' user, the public one should be set on remote
 # servers to backup (see the role 'rsnapshot-slave')
-rsnapshot_ssh_key: id_rsa
+rsnapshot_master_ssh_key: id_rsa
 rsnapshot_master_host_user:  root
 
 # This is needed if you plan to backup localhost files as non root user
@@ -107,7 +107,7 @@ rsnapshot_config_lockfile: /var/run/rsnapshot.pid
 rsnapshot_config_stop_on_stale_lockfile: 0
 rsnapshot_config_rsync_short_args: False
 rsnapshot_config_rsync_long_args: '--delete --numeric-ids --relative --delete-excluded --rsync-path=rsync-wrapper.sh'
-rsnapshot_config_ssh_args: '-i $HOME/.ssh/{{ rsnapshot_ssh_key }}'
+rsnapshot_config_ssh_args: '-i $HOME/.ssh/{{ rsnapshot_master_ssh_key }}'
 rsnapshot_config_du_args: False
 rsnapshot_config_one_fs: False
 rsnapshot_config_include: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,8 +39,8 @@ rsnapshot_config_stop_on_stale_lockfile: 0
 rsnapshot_config_rsync_short_args: False
 rsnapshot_config_rsync_long_args: '--delete --numeric-ids --relative --delete-excluded --rsync-path=rsync-wrapper.sh'
 rsnapshot_config_rsync_long_args_not_root: "--fake-super {{rsnapshot_config_rsync_long_args}}"
-rsnapshot_config_ssh_args: '-i /root/.ssh/{{ rsnapshot_ssh_key }}'
-rsnapshot_config_ssh_args_not_root: "-i /home/{{rsnapshot_master_host_user}}/.ssh/{{ rsnapshot_ssh_key }}"
+rsnapshot_config_ssh_args: '-i /root/.ssh/{{ rsnapshot_master_ssh_key }}'
+rsnapshot_config_ssh_args_not_root: "-i /home/{{rsnapshot_master_host_user}}/.ssh/{{ rsnapshot_master_ssh_key }}"
 rsnapshot_config_du_args: False
 rsnapshot_config_one_fs: False
 rsnapshot_config_include: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 
 # SSH key for the 'root' user, the public one should be set on remote
 # servers to backup (see the role 'rsnapshot-slave')
-rsnapshot_ssh_key: id_rsa
+rsnapshot_master_ssh_key: id_rsa
 rsnapshot_master_host_user:  "{{ ansible_ssh_user }}"
 
 # rsnapshot options

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 # SSH key for the 'root' user, the public one should be set on remote
 # servers to backup (see the role 'rsnapshot-slave')
 rsnapshot_ssh_key: id_rsa
+rsnapshot_master_host_user:  "{{ ansible_ssh_user }}"
 
 # rsnapshot options
 rsnapshot_config_file: /etc/rsnapshot.conf

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -59,6 +59,7 @@ rsnapshot_config_backup:
           - [backup, /usr/local/, localhost/]
 
 # rsnapshot crontab
+rsnapshot_cron_file: ansible_rsnapshot
 rsnapshot_crontab_env: {}
 rsnapshot_crontab:
     - name: hourly

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,10 @@
 # SSH key for the 'root' user, the public one should be set on remote
 # servers to backup (see the role 'rsnapshot-slave')
 rsnapshot_master_ssh_key: id_rsa
-rsnapshot_master_host_user:  "{{ ansible_ssh_user }}"
+rsnapshot_master_host_user:  root
+
+# This is needed if you plan to backup localhost files as non root user
+rsnapshot_master_host_user_uses_sudo: True
 
 # rsnapshot options
 rsnapshot_config_file: /etc/rsnapshot.conf
@@ -30,12 +33,14 @@ rsnapshot_config_intervals:
       value: 3
 rsnapshot_config_verbose: 2
 rsnapshot_config_loglevel: 3
-rsnapshot_config_logfile: /var/log/rsnapshot.log
-rsnapshot_config_lockfile: /var/run/rsnapshot.pid
+rsnapshot_config_logfile: /var/log/rsnapshot/rsnapshot.log
+rsnapshot_config_lockfile: /var/run/rsnapshot/rsnapshot.pid
 rsnapshot_config_stop_on_stale_lockfile: 0
 rsnapshot_config_rsync_short_args: False
 rsnapshot_config_rsync_long_args: '--delete --numeric-ids --relative --delete-excluded --rsync-path=rsync-wrapper.sh'
+rsnapshot_config_rsync_long_args_not_root: "--fake-super {{rsnapshot_config_rsync_long_args}}"
 rsnapshot_config_ssh_args: '-i /root/.ssh/{{ rsnapshot_ssh_key }}'
+rsnapshot_config_ssh_args_not_root: "-i /home/{{rsnapshot_master_host_user}}/.ssh/{{ rsnapshot_ssh_key }}"
 rsnapshot_config_du_args: False
 rsnapshot_config_one_fs: False
 rsnapshot_config_include: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ rsnapshot_master_ssh_key: id_rsa
 rsnapshot_master_host_user:  root
 
 # This is needed if you plan to backup localhost files as non root user
-rsnapshot_master_host_user_uses_sudo: True
+rsnapshot_master_host_user_uses_sudo: False
 
 # rsnapshot options
 rsnapshot_config_file: /etc/rsnapshot.conf

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 # SSH key for the 'root' user, the public one should be set on remote
 # servers to backup (see the role 'rsnapshot-slave')
 rsnapshot_master_ssh_key: id_rsa
-rsnapshot_master_host_user:  root
+rsnapshot_master_host_user: root
 
 # This is needed if you plan to backup localhost files as non root user
 rsnapshot_master_host_user_uses_sudo: False

--- a/files/rsync-wrapper.sh
+++ b/files/rsync-wrapper.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+/usr/bin/sudo /usr/bin/rsync "$@";

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -15,8 +15,8 @@ galaxy_info:
         - stretch
     - name: Ubuntu
       versions:
-        - precise
         - trusty
+        - bionic
   categories:
     - system
 dependencies: []

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
       It works in conjunction with the rsnapshot-slave role.
   company: OSIELL
   license: GPLv3
-  min_ansible_version: 1.8
+  min_ansible_version: 2.4
   platforms:
     - name: Debian
       versions:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -23,7 +23,7 @@
 
 - name: Configure cron (environment variables)
   cron:
-    cron_file: ansible_rsnapshot
+    cron_file: "{{ rsnapshot_cron_file }}"
     user: "{{rsnapshot_master_host_user}}"
     name: "{{ item.key }}"
     value: "{{ item.value }}"
@@ -34,7 +34,7 @@
   cron:
     name: "{{ item.name }}"
     user: "{{rsnapshot_master_host_user}}"
-    cron_file: ansible_rsnapshot
+    cron_file: "{{ rsnapshot_cron_file }}"
     month: "{{ item.get('month', '*') }}"
     weekday: "{{ item.get('weekday', '*') }}"
     day: "{{ item.get('day', '*') }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -3,7 +3,7 @@
 - name: "Create a SSH key for master user {{rsnapshot_master_host_user}}"
   user: name="{{rsnapshot_master_host_user}}"
         generate_ssh_key=yes
-        ssh_key_file=.ssh/{{ rsnapshot_ssh_key }}
+        ssh_key_file=.ssh/{{ rsnapshot_master_ssh_key }}
   when: rsnapshot_ssh_key != False
   tags:
     - rsnapshot_config_ssh

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -71,4 +71,3 @@
     mode: 0644
   when: rsnapshot_config_lockfile | dirname != '/run' and rsnapshot_config_lockfile | dirname != '/var/run' and rsnapshot_config_lockfile | dirname | regex_search("^(/var)?/run/")
   tags: ['new']
-

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,6 +5,7 @@
     name: "{{rsnapshot_master_host_user}}"
     generate_ssh_key: yes
     ssh_key_file: ".ssh/{{ rsnapshot_master_ssh_key }}"
+    ssh_key_comment: "rsnapshot master user {{ rsnapshot_master_host_user }} at {{ inventory_hostname }}"
   when: rsnapshot_master_ssh_key != False
   tags:
     - rsnapshot_config_ssh

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -34,3 +34,33 @@
         minute={{ item.get('minute', '*') }}
         job="{{ item.get('job', '*') }}"
   with_items: "{{ rsnapshot_crontab }}"
+
+- name: Create default log folder (needed if not run as root)
+  file:
+    state: directory
+    path: "{{ rsnapshot_config_logfile | dirname }}"
+    owner: "{{ rsnapshot_master_host_user }}"
+    group: "{{ rsnapshot_master_host_user }}"
+    mode: 0700
+  when: rsnapshot_config_logfile | dirname != '/var/log'
+
+- name: Create default run folder (needed if not run as root)
+  file:
+    state: directory
+    path: "{{ rsnapshot_config_logfile | dirname }}"
+    owner: "{{ rsnapshot_master_host_user }}"
+    group: "{{ rsnapshot_master_host_user }}"
+    mode: 0700
+  when: rsnapshot_config_lockfile | dirname != '/run' and rsnapshot_config_lockfile | dirname != '/var/run'
+
+# on ubuntu, /var/run is tmpfs, so subdirectories are removed on reboot
+- name: Ensure the run folder is created on boot
+  template:
+    src: ./templates/tmpfiles.d_rsnapshot.conf
+    dest: /usr/lib/tmpfiles.d/rsnapshot.conf
+    owner: root
+    group: root
+    mode: 0644
+  when: rsnapshot_config_lockfile | dirname != '/run' and rsnapshot_config_lockfile | dirname != '/var/run' and rsnapshot_config_lockfile | dirname | regex_search("^(/var)?/run/")
+  tags: ['new']
+

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,7 +1,7 @@
 ---
 
-- name: Create a SSH key for 'root'
-  user: name=root
+- name: "Create a SSH key for master user {{rsnapshot_master_host_user}}"
+  user: name="{{rsnapshot_master_host_user}}"
         generate_ssh_key=yes
         ssh_key_file=.ssh/{{ rsnapshot_ssh_key }}
   when: rsnapshot_ssh_key != False
@@ -10,14 +10,14 @@
 
 - name: Configure rsnapshot
   template: src=rsnapshot.conf.j2 dest={{ rsnapshot_config_file }}
-        owner=root group=root mode=0644
+        owner="{{rsnapshot_master_host_user}}" group=root mode=0644
         backup=yes
   tags:
     - rsnapshot_config_file
 
 - name: Configure cron (environment variables)
   cron: cron_file=ansible_rsnapshot
-        user=root
+        user="{{rsnapshot_master_host_user}}"
         name={{ item.key }}
         value={{ item.value }}
         env=yes
@@ -25,7 +25,7 @@
 
 - name: Configure cron
   cron: name={{ item.name }}
-        user=root
+        user="{{rsnapshot_master_host_user}}"
         cron_file=ansible_rsnapshot
         month={{ item.get('month', '*') }}
         weekday={{ item.get('weekday', '*') }}

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -54,7 +54,7 @@
 - name: Create default run folder (needed if not run as root)
   file:
     state: directory
-    path: "{{ rsnapshot_config_logfile | dirname }}"
+    path: "{{ rsnapshot_config_lockfile | dirname }}"
     owner: "{{ rsnapshot_master_host_user }}"
     group: "{{ rsnapshot_master_host_user }}"
     mode: 0700

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,38 +1,45 @@
 ---
 
 - name: "Create a SSH key for master user {{rsnapshot_master_host_user}}"
-  user: name="{{rsnapshot_master_host_user}}"
-        generate_ssh_key=yes
-        ssh_key_file=.ssh/{{ rsnapshot_master_ssh_key }}
+  user:
+    name: "{{rsnapshot_master_host_user}}"
+    generate_ssh_key: yes
+    ssh_key_file: ".ssh/{{ rsnapshot_master_ssh_key }}"
   when: rsnapshot_ssh_key != False
   tags:
     - rsnapshot_config_ssh
 
 - name: Configure rsnapshot
-  template: src=rsnapshot.conf.j2 dest={{ rsnapshot_config_file }}
-        owner="{{rsnapshot_master_host_user}}" group=root mode=0644
-        backup=yes
+  template:
+    src: rsnapshot.conf.j2
+    dest: "{{ rsnapshot_config_file }}"
+    owner: "{{rsnapshot_master_host_user}}"
+    group: root
+    mode: 0644
+    backup: yes
   tags:
     - rsnapshot_config_file
 
 - name: Configure cron (environment variables)
-  cron: cron_file=ansible_rsnapshot
-        user="{{rsnapshot_master_host_user}}"
-        name={{ item.key }}
-        value={{ item.value }}
-        env=yes
+  cron:
+    cron_file: ansible_rsnapshot
+    user: "{{rsnapshot_master_host_user}}"
+    name: "{{ item.key }}"
+    value: "{{ item.value }}"
+    env: yes
   with_dict: "{{ rsnapshot_crontab_env }}"
 
 - name: Configure cron
-  cron: name={{ item.name }}
-        user="{{rsnapshot_master_host_user}}"
-        cron_file=ansible_rsnapshot
-        month={{ item.get('month', '*') }}
-        weekday={{ item.get('weekday', '*') }}
-        day={{ item.get('day', '*') }}
-        hour={{ item.get('hour', '*') }}
-        minute={{ item.get('minute', '*') }}
-        job="{{ item.get('job', '*') }}"
+  cron:
+    name: "{{ item.name }}"
+    user: "{{rsnapshot_master_host_user}}"
+    cron_file: ansible_rsnapshot
+    month: "{{ item.get('month', '*') }}"
+    weekday: "{{ item.get('weekday', '*') }}"
+    day: "{{ item.get('day', '*') }}"
+    hour: "{{ item.get('hour', '*') }}"
+    minute: "{{ item.get('minute', '*') }}"
+    job: "{{ item.get('job', '*') }}"
   with_items: "{{ rsnapshot_crontab }}"
 
 - name: Create default log folder (needed if not run as root)

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,7 +5,7 @@
     name: "{{rsnapshot_master_host_user}}"
     generate_ssh_key: yes
     ssh_key_file: ".ssh/{{ rsnapshot_master_ssh_key }}"
-  when: rsnapshot_ssh_key != False
+  when: rsnapshot_master_ssh_key != False
   tags:
     - rsnapshot_config_ssh
 

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,10 +1,11 @@
 ---
 
 - name: Install rsnapshot
-  apt:  pkg=rsnapshot
-        state=present
-        update_cache={{ rsnapshot_apt_update_cache }}
-        cache_valid_time={{ rsnapshot_apt_cache_valid_time }}
+  apt:
+    pkg: rsnapshot
+    state: present
+    update_cache: "{{ rsnapshot_apt_update_cache }}"
+    cache_valid_time: "{{ rsnapshot_apt_cache_valid_time }}"
 
 - name: Install sudo
   apt:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,3 +5,9 @@
         state=installed
         update_cache={{ rsnapshot_apt_update_cache }}
         cache_valid_time={{ rsnapshot_apt_cache_valid_time }}
+
+- name: Install sudo
+  apt:
+    pkg: sudo
+    state: present
+  when: rsnapshot_master_host_user != 'root' and rsnapshot_master_host_user_uses_sudo

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,7 +2,7 @@
 
 - name: Install rsnapshot
   apt:  pkg=rsnapshot
-        state=installed
+        state=present
         update_cache={{ rsnapshot_apt_update_cache }}
         cache_valid_time={{ rsnapshot_apt_cache_valid_time }}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
 
-- include: install.yml
+- import_tasks: install.yml
   tags:
     - rsnapshot
     - rsnapshot_install
 
-- include: config.yml
+- import_tasks: config.yml
   tags:
     - rsnapshot
     - rsnapshot_config
 
-- include: not-root.yml
+- include_tasks: not-root.yml
   when: rsnapshot_master_host_user != 'root' and rsnapshot_master_host_user_uses_sudo
   tags:
     - rsnapshot

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,7 @@
     - rsnapshot_config
 
 - include: not-root.yml
-  when: rsnapshot_master_host_user != 'root'
+  when: rsnapshot_master_host_user != 'root' and rsnapshot_master_host_user_uses_sudo
   tags:
     - rsnapshot
     - rsnapshot_config

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,3 +9,9 @@
   tags:
     - rsnapshot
     - rsnapshot_config
+
+- include: not-root.yml
+  when: rsnapshot_master_host_user != 'root'
+  tags:
+    - rsnapshot
+    - rsnapshot_config

--- a/tasks/not-root.yml
+++ b/tasks/not-root.yml
@@ -3,7 +3,7 @@
 - name: Sudo configuration for the backup system user
   template:
     src: sudo_backupuser
-    dest: "/etc/sudoers.d/{{ rsnapshot_slave_user }}"
+    dest: "/etc/sudoers.d/{{ rsnapshot_master_host_user }}"
     owner: root
     group: root
     mode: 0440

--- a/tasks/not-root.yml
+++ b/tasks/not-root.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Sudo configuration for the backup system user
+  template:
+    src: sudo_backupuser
+    dest: "/etc/sudoers.d/{{ rsnapshot_slave_user }}"
+    owner: root
+    group: root
+    mode: 0440
+  when: ansible_os_family == "Debian" and ansible_lsb.major_release|int >= 6
+
+- name: Install the 'rsync-wrapper.sh' script, for rights elevation for localhost backup
+  copy:
+    src: rsync-wrapper.sh
+    dest: /usr/local/bin/rsync-wrapper.sh
+    owner: root
+    group: root
+    mode: 0755

--- a/templates/rsnapshot.conf.j2
+++ b/templates/rsnapshot.conf.j2
@@ -48,7 +48,7 @@ cmd_rm		{{ rsnapshot_config_cmd_rm }}
 # rsync must be enabled for anything to work. This is the only command that
 # must be enabled.
 #
-cmd_rsync	{{ rsnapshot_config_cmd_rsync }}
+cmd_rsync	{%if rsnapshot_master_host_user_uses_sudo and rsnapshot_master_host_user != 'root' %}/usr/local/bin/rsync-wrapper.sh{%else%}{{ rsnapshot_config_cmd_rsync }}{%endif%}
 
 # Uncomment this to enable remote ssh backups over rsync.
 #
@@ -170,7 +170,11 @@ rsync_short_args	{{ rsnapshot_config_rsync_short_args }}
 #rsync_short_args	-a
 {% endif %}
 {% if rsnapshot_config_rsync_long_args %}
+{% if rsnapshot_master_host_user == 'root' or rsnapshot_master_host_user_uses_sudo %}
 rsync_long_args	{{ rsnapshot_config_rsync_long_args }}
+{%else%}
+rsync_long_args	{{ rsnapshot_config_rsync_long_args_not_root }}
+{%endif%}
 {% else %}
 #rsync_long_args	--delete --numeric-ids --relative --delete-excluded
 {% endif %}
@@ -178,7 +182,11 @@ rsync_long_args	{{ rsnapshot_config_rsync_long_args }}
 # ssh has no args passed by default, but you can specify some here.
 #
 {% if rsnapshot_config_ssh_args %}
+{% if rsnapshot_master_host_user == 'root' %}
 ssh_args	{{ rsnapshot_config_ssh_args }}
+{%else%}
+ssh_args	{{ rsnapshot_config_ssh_args_not_root }}
+{%endif%}
 {% else %}
 #ssh_args	-p 22
 {% endif %}

--- a/templates/sudo_backupuser
+++ b/templates/sudo_backupuser
@@ -1,0 +1,1 @@
+{{ rsnapshot_master_host_user }} ALL=(ALL) NOPASSWD: /usr/bin/rsync

--- a/templates/tmpfiles.d_rsnapshot.conf
+++ b/templates/tmpfiles.d_rsnapshot.conf
@@ -1,0 +1,2 @@
+#Type Path            Mode UID      GID    Age Argument
+ d     {{rsnapshot_config_lockfile | dirname }}   0755 {{rsnapshot_master_host_user}} {{rsnapshot_master_host_user}}   -   -

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -2,10 +2,10 @@
 # Check the role/playbook's syntax.
 ansible-playbook -i tests/inventory tests/test.yml --syntax-check || exit 1
 # Run the role/playbook with ansible-playbook.
-ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo || exit 1
+ansible-playbook -i tests/inventory tests/test.yml --connection=local || exit 1
 # Run the role/playbook again, checking to make sure it's idempotent.
 output_log=output_log.log
-ansible-playbook -i tests/inventory tests/test.yml --connection=local --sudo -v > $output_log || exit 1
+ansible-playbook -i tests/inventory tests/test.yml --connection=local -v > $output_log || exit 1
 grep -q 'changed=0.*failed=0' $output_log \
     && (echo 'IDEMPOTENCE TEST: OK' && exit 0) \
     || (echo 'IDEMPOTENCE TEST: FAILED' && cat $output_log && exit 1) || exit 1

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,6 +1,7 @@
 ---
 
 - hosts: localhost
+  become: True
   remote_user: root
   roles:
     - ansible-rsnapshot-master


### PR DESCRIPTION
The "ansible-rsnapshot-slave" role introduces a configurable variable `rsnapshot_master_host_user` which is non configurable in the "ansible-rsnapshot-master" role.

This PR introduces the ability to run rsnasphot as non root user, but leaves the default user as root.

There is some non functional changes like YAML syntax everywhere and some deprecations warnings.